### PR TITLE
Multiple options hydration

### DIFF
--- a/lib/hydration.js
+++ b/lib/hydration.js
@@ -2,15 +2,24 @@ const { dotify } = require('./utils');
 const klona = require('klona');
 const dotProp = require('dot-prop');
 
-const hydrateOptions = (fields, key, value) => {
-  const options = dotProp.get(fields, `${key}._options`);
+const hydrateOption = (options, value) => {
   const selectedOption = options.find(option => option._attributes.value === value);
-
   if (selectedOption) {
     if (selectedOption.hasOwnProperty('_attributes')) {
       selectedOption._attributes.selected = true;
       selectedOption._attributes.checked = true;
     }
+  }
+}
+
+const hydrateOptions = (fields, key, value) => {
+  const field = dotProp.get(fields, key);
+  const options = dotProp.get(fields, `${key}._options`);
+
+  if (field._multiple && Array.isArray(value)) {
+    value.forEach((val) => hydrateOption(options, val));
+  } else {
+    hydrateOption(options, value);
   }
 }
 

--- a/test/hydration.js
+++ b/test/hydration.js
@@ -471,6 +471,46 @@ describe('Hydating doc' , () => {
     expect(actual.gifts._attributes.checked).to.equal(true);
   });
 
+  it('hydrates pick multiple values', () => {
+    const actual = toFields({
+      flags: {
+        _input: 'pick',
+        _type: 'chips',
+        _multiple: true,
+        _options: [
+          {
+            label: 'Uno',
+            value: 'UNO'
+          },
+          {
+            label: 'Dos',
+            value: 'DOS'
+          },
+          {
+            label: 'Tres',
+            value: 'TRES'
+          }
+        ]
+      }
+    }, {
+      flags: ['UNO', 'TRES']
+    });
+
+    expect(actual.flags._options).to.containSubset([{
+      _attributes: {
+        value: 'UNO',
+        checked: true
+      }
+    }]);
+
+    expect(actual.flags._options).to.containSubset([{
+      _attributes: {
+        value: 'TRES',
+        checked: true
+      }
+    }]);
+  });
+
   describe('errors', () => {
     it('hydrates simple errors', () => {
       const actual = toFields({


### PR DESCRIPTION
Hey, can you review this?

Here is the use case:

In hub > accounts > detail > profile you can edit `flags`. I'm working on changing that input from combobox to a pick:chips input. This will allow multiple choice of the chip checkboxes. So locally I changed to this input but the problem is hydration wasn't working... because the `account.flags` is an array and we don't hydrate arrays yet. Anyway, I think I've got it working but I need a second pair of eyes to decide whether we want this implementation or not, and if you see any issues with this.

If you're good with this **do not** merge this in and delete because we probably need to discuss a couple scenarios after your initial review.