### PR TITLE
Postal code validation

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -465,6 +465,7 @@ exports.address = (_options = countries, attributes) => {
       _input: 'input',
       _attributes: {
         type: 'text',
+        pattern: '[a-zA-Z\\d\\s\\-]+',
         ...requiredCondition,
         ...disabledCondition,
         autocomplete: 'postal-code',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formgive",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formgive",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Form structures",
   "license": "MIT",
   "keywords": [

--- a/test/schema-parsing.js
+++ b/test/schema-parsing.js
@@ -596,6 +596,14 @@ describe('Schema parsing', () => {
             _attributes: {
               required: false
             }
+          },
+          postalCode: {
+            _attributes: {
+              name: 'address.postalCode',
+              pattern: '[a-zA-Z\\d\\s\\-]+'
+            },
+            _key: 'postalCode',
+            _label: 'Postal code',
           }
         });
       });


### PR DESCRIPTION
@shanebo A couple notes:

1) I added the pattern validation on the post code field within address. Let me know if you want me to make postal code work as a field apart from the address field.

2) I npm linked this to the ui app, then tested locally in both Safari and Chrome. It worked as expected in both.